### PR TITLE
Add proper tags to docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,47 +1,46 @@
 name: Build Docker Image
 
 on:
-  workflow_run:
-    workflows: [ "tests" ]
-    branches: [ main ]
-    types: [ "completed" ]
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
-      - workflow
-      - workflowhub
-      - seek-1.11
-      - seek-1.12
-      - seek-1.13
-      - master-ibisba-demonstrator
-      - ruby-3
-  pull_request:
+  release:
+    types:
+      - published
+  workflow_dispatch:
 
 jobs:
   build:
     name: "Build Image"
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - id: generate-image-tag
-        name: Generate Image Tag
-        env:
-          ref_name: "${{ github.ref_name }}"
-          head_ref: "${{ github.head_ref }}"
-        run: |
-          ref_name="${head_ref:-${ref_name/main/latest}}"
-          echo "::set-output name=imageTag::${ref_name#v}"
+        uses: actions/checkout@v4
+      - name: Generate Image Tags
+        id: generate-image-tags
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
       - name: Login to Container Registry
-        uses: docker/login-action@v1
+        if: contains(fromJSON('["release", "workflow_dispatch"]'), github.event_name)
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: ghcr.io/${{ github.repository }}:${{ steps.generate-image-tag.outputs.imageTag }}
+          push: ${{ contains(fromJSON('["release", "workflow_dispatch"]'), github.event_name) }}
+          tags: ${{ steps.generate-image-tags.outputs.tags }}
+          labels: ${{ steps.generate-image-tags.outputs.labels }}


### PR DESCRIPTION
## Changes

This pull request will generate additional docker image tags.

There are essentially two scenarios in which an image is created and published:

1. Pushing a **commit** to `main` branch will always add an additional tag containing a hash code.

2. Pushing a **tag** to `main` branch will add the semantic version number as image tag.

Previous image versions are retained.

See [docker/metadata-action](https://github.com/docker/metadata-action?tab=readme-ov-file) documentation for more information.

## Some Notes

There is currently a check in place that prevents the "Build Docker Image" workflow from running, if there is no successful "tests" workflow (`if: ${{ github.event.workflow_run.conclusion == 'success' }}`). This will cause the workflow to be started and immediately skipped, rendering the workflow's `on.push` and `on.pull_request` conditions useless (see `.github/workflows/docker-image.yml`).